### PR TITLE
fix: repeated addPerkGroupToTooltips calls

### DIFF
--- a/dynamic_perks/config.nut
+++ b/dynamic_perks/config.nut
@@ -210,9 +210,6 @@ foreach (i, row in ::Const.Perks.Perks)
 		local mid = "";
 		local ap = "perk group[/color]";
 
-		local perk = ::Const.Perks.findById(perkID);
-		local desc = perk.Tooltip;
-
 		if (groups.len() == 1)
 		{
 			mid += groups[0] + " ";
@@ -228,37 +225,16 @@ foreach (i, row in ::Const.Perks.Perks)
 			ap = "perk groups[/color]";
 		}
 
-		if (desc.find(pre) == null)
+		local perk = ::Const.Perks.findById(perkID);
+		local index = perk.Tooltip.find(pre);
+		if (index == null)
 		{
 			perk.Tooltip += "\n\n" + pre + mid + ap;
 		}
 		else
 		{
-			local strArray = split(desc, "[");
-
-			strArray.pop();
-			strArray.apply(@(a) a += "[" );
-
-			strArray[strArray.len()-1] = "color=#0b0084]From the " + mid + ap;
-
-			if (strArray[0].find("color=") != null)
-			{
-				strArray[0] = "[" + strArray[0];
-			}
-
-			local ret = "";
-			foreach (s in strArray)
-			{
-				ret += s;
-			}
-
-			if (ret.find("\n\n" + pre) == null)
-			{
-				local prefix = ret.find("\n" + pre) == null ? "\n\n" : "\n";
-				ret = ::MSU.String.replace(ret, pre, prefix + pre);
-			}
-
-			perk.Tooltip += text;
+			perk.Tooltip = perk.Tooltip.slice(0, index);
+			perk.Tooltip += pre + mid + ap;
 		}
 	}
 }


### PR DESCRIPTION
Repeated calls of this function never worked because the variable `text` was unknown.
This situation happens when submods switch around perks in the groups and want to update the perk tooltips accordingly.

The logic in this function for updating tooltips was also very complicated and ambitious by just splitting with the character `[`.
I rewrote this in a simpler way.

I tested this with my mod and after moving Bags and Belts to Light Armor I just had to call the addPerkGroupToTooltips to get to this updated tooltip.

![image](https://github.com/Battle-Modders/Dynamic-Perks-Framework/assets/2252464/d809ec7b-115d-4808-ae44-6656deb8681d)
