### PR TITLE
fix: negative perk tier after resetting all perks

### DIFF
--- a/dynamic_perks/hooks/entity/tactical/player.nut
+++ b/dynamic_perks/hooks/entity/tactical/player.nut
@@ -58,6 +58,7 @@
 			this.m.PerkPoints++;
 			this.m.PerkPointsSpent--;
 		}
+		this.m.PerkPointsSpent = ::Math.max(0, this.m.PerkPointsSpent);		// If this goes into the negatives because something added refundable perks, then the PerkTier will be negative
 
 		this.resetPerkTier();
 		


### PR DESCRIPTION
In my tests, I added perks to my brothers so I could test them out. 
Later in the tests I wanted them to learn other perks but didnt bother adding them per console, instead I used oblivion potions on them to respecc.
However because the amount of perks they have was far greater than the `PerkPointsSpent` variable on them, this variable went into the negatives after respeccing. And that caused the perk tier to be negative. So they couldnt learn anything anymore