### PR TITLE
feat: add onBuildPerkTree for starting_scenario

### DIFF
--- a/dynamic_perks/hooks/scenarios/world/starting_scenario.nut
+++ b/dynamic_perks/hooks/scenarios/world/starting_scenario.nut
@@ -1,5 +1,5 @@
 ::DynamicPerks.HooksMod.hook("scripts/scenarios/world/starting_scenario", function (q) {
-	q.onBuildPerkTree <- function( _bro )
+	q.onBuildPerkTree <- function( _perkTree )
 	{
 	}
 });

--- a/dynamic_perks/hooks/scenarios/world/starting_scenario.nut
+++ b/dynamic_perks/hooks/scenarios/world/starting_scenario.nut
@@ -1,0 +1,5 @@
+::DynamicPerks.HooksMod.hook("scripts/scenarios/world/starting_scenario", function (q) {
+	q.onBuildPerkTree <- function( _bro )
+	{
+	}
+});

--- a/scripts/mods/mod_dynamic_perks/classes/perk_tree.nut
+++ b/scripts/mods/mod_dynamic_perks/classes/perk_tree.nut
@@ -134,7 +134,15 @@ this.perk_tree <- ::inherit(::MSU.BBClass.Empty, {
 
 		this.m.Exclude = null;
 
-		if (!::MSU.isNull(this.getActor())) this.getActor().getBackground().onBuildPerkTree();
+		if (!::MSU.isNull(this.getActor()))
+		{
+			this.getActor().getBackground().onBuildPerkTree();
+
+			if ("Assets" in ::World && !::MSU.isNull(::World.Assets))
+			{
+				::World.Assets.getOrigin().onBuildPerkTree(this.getActor());
+			}
+		}
 	}
 
 	function buildFromDynamicMap()

--- a/scripts/mods/mod_dynamic_perks/classes/perk_tree.nut
+++ b/scripts/mods/mod_dynamic_perks/classes/perk_tree.nut
@@ -137,11 +137,11 @@ this.perk_tree <- ::inherit(::MSU.BBClass.Empty, {
 		if (!::MSU.isNull(this.getActor()))
 		{
 			this.getActor().getBackground().onBuildPerkTree();
+		}
 
-			if ("Assets" in ::World && !::MSU.isNull(::World.Assets))
-			{
-				::World.Assets.getOrigin().onBuildPerkTree(this.getActor());
-			}
+		if ("Assets" in ::World && !::MSU.isNull(::World.Assets))
+		{
+			::World.Assets.getOrigin().onBuildPerkTree(this);
 		}
 	}
 


### PR DESCRIPTION
This will allow origins to make custom changes to perk trees of all bros e.g. guaranteeing the appearance of certain perks.