### PR TITLE
feat: add two tips of the day

### DIFF
--- a/dynamic_perks/hooks/config/tip_of_the_day.nut
+++ b/dynamic_perks/hooks/config/tip_of_the_day.nut
@@ -1,0 +1,4 @@
+::Const.TipOfTheDay.extend([
+	"Dynamic Perks: You can press \'Shift\' while hovering over a perk in your perk tree to highlight all other perks of the same group.",
+	"Dynamic Perks: You can access a complete perk overview with search function by clicking on the [DP] button when viewing a brother\'s perk tree."
+]);


### PR DESCRIPTION
Midas considered pulling the hotkey for highlighting from the mod settings automatically but for this first implementation I decided against it.
- I haven't done that before
- The hotkey might be wrong as the savegame's hotkeys might not be loaded yet at this time
- This tip is 99% of the time directed towards new player who will still have that feature on the hotkey shift

Here an example on how the second tip about the [DP] button looks ingame:
![image](https://github.com/user-attachments/assets/8c07b204-5604-49b3-b26a-8ec7fc5dad7f)