### PR TITLE
feat!: add function to generate perk tree of background

### DIFF
--- a/dynamic_perks/hooks/entity/tactical/player.nut
+++ b/dynamic_perks/hooks/entity/tactical/player.nut
@@ -107,7 +107,7 @@
 		q.setStartValuesEx = @(__original) function( _backgrounds, _addTraits = true )
 		{
 			__original(_backgrounds, _addTraits);
-			this.m.PerkTree = this.getBackground().createPerkTree();
+			this.m.PerkTree = this.getBackground().createPerkTreeBlueprint();
 			this.m.PerkTree.setActor(this);
 			this.m.PerkTree.build();
 		}

--- a/dynamic_perks/hooks/entity/tactical/player.nut
+++ b/dynamic_perks/hooks/entity/tactical/player.nut
@@ -107,7 +107,7 @@
 		q.setStartValuesEx = @(__original) function( _backgrounds, _addTraits = true )
 		{
 			__original(_backgrounds, _addTraits);
-			this.m.PerkTree = this.getBackground().m.PerkTree;
+			this.m.PerkTree = this.getBackground().createPerkTree();
 			this.m.PerkTree.setActor(this);
 			this.m.PerkTree.build();
 		}

--- a/dynamic_perks/hooks/skills/backgrounds/character_background.nut
+++ b/dynamic_perks/hooks/skills/backgrounds/character_background.nut
@@ -1,5 +1,5 @@
 ::DynamicPerks.HooksMod.hook("scripts/skills/backgrounds/character_background", function(q) {
-	q.createPerkTree <- function()
+	q.createPerkTreeBlueprint <- function()
 	{
 		return ::new(::DynamicPerks.Class.PerkTree).init({Template = ::DynamicPerks.DefaultPerkTreeTemplate});
 	}

--- a/dynamic_perks/hooks/skills/backgrounds/character_background.nut
+++ b/dynamic_perks/hooks/skills/backgrounds/character_background.nut
@@ -1,10 +1,7 @@
 ::DynamicPerks.HooksMod.hook("scripts/skills/backgrounds/character_background", function(q) {
-	q.m.PerkTree <- null;
-
-	q.create = @(__original) function()
+	q.createPerkTree <- function()
 	{
-		this.m.PerkTree = ::new(::DynamicPerks.Class.PerkTree).init({Template = ::DynamicPerks.DefaultPerkTreeTemplate});
-		__original();
+		return ::new(::DynamicPerks.Class.PerkTree).init({Template = ::DynamicPerks.DefaultPerkTreeTemplate});
 	}
 
 	q.onBuildPerkTree <- function()


### PR DESCRIPTION
Instead of generating it always during create in a member this.m.PerkTree variable.

This will break backwards compatibility but I believe this is a better structure for the code going forward. Do you have any further suggestions for improvements? Is the name of the function ok?