### PR TITLE
feat!: remove getMultiplier from special perk group

### DIFF
--- a/scripts/mods/mod_dynamic_perks/classes/special_perk_group.nut
+++ b/scripts/mods/mod_dynamic_perks/classes/special_perk_group.nut
@@ -12,18 +12,13 @@ this.special_perk_group <- ::inherit(::DynamicPerks.Class.PerkGroup, {
 		return this.m.Chance;
 	}
 
-	function getMultiplier( _perkTree )
-	{
-		return 1.0;
-	}
-
 	function calculateChance( _perkTree )
 	{
 		local chance = this.getChance();
 
 		if (chance < 0) return 100;
 
-		chance *= this.getMultiplier(_perkTree);
+		chance *= this.getSelfMultiplier(_perkTree);
 		if (chance < 0) return 100;
 
 		local myID = this.getID();


### PR DESCRIPTION
Because this class inherits from perk_group which has the `getSelfMultiplier` function. That function seems to be the correct place to apply multiplier to this group's own chance because within its own `calculateChance` function, multipliers from other sources use the expected `getPerkGroupMultiplier` function to apply their multipliers to it just like for regular perk groups.

This will break backwards compatibility but seems like a better thing to do now combined with the #28 PR which is also a breaking change.