### PR TITLE
feat!: add method for skills to affect perk unlockability

### DIFF
--- a/dynamic_perks/hooks/entity/tactical/player.nut
+++ b/dynamic_perks/hooks/entity/tactical/player.nut
@@ -33,11 +33,10 @@
 		if (this.getPerkTier() < this.getPerkTree().getPerkTier(_id))
 			return false;
 
-		local perk = this.getPerkTree().getPerk(_id);
-		if ((::MSU.isIn("verifyPrerequisites", perk, true)) && !perk.verifyPrerequisites(this, [])) // TODO: Efficiency issue: passing an empty array every time
-			return false;
-
-		return true;
+		// The tooltip is pointless here but the functions expect it so we pass an empty array
+		local tooltip = [];
+		local ret = this.getPerkTree().getPerk(_id).isUnlockable(this, tooltip);
+		return this.getSkills().isPerkUnlockable(_id, tooltip) && ret;
 	}
 
 	q.unlockPerk = @(__original) function( _id )

--- a/dynamic_perks/hooks/skills/skill.nut
+++ b/dynamic_perks/hooks/skills/skill.nut
@@ -11,6 +11,11 @@
 		return 1.0;
 	}
 
+	q.isPerkUnlockable <- function( _perkID, _tooltip )
+	{
+		return true;
+	}
+
 	q.onSerialize = @(__original) function( _out )
 	{
 		__original(_out);

--- a/dynamic_perks/hooks/skills/skill_container.nut
+++ b/dynamic_perks/hooks/skills/skill_container.nut
@@ -1,0 +1,19 @@
+::DynamicPerks.HooksMod.hook("scripts/skills/skill_container", function (q) {
+	q.isPerkUnlockable <- function( _perkID, _tooltip )
+	{
+		local ret = true;
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+			{
+				ret = s.isPerkUnlockable(_perkID, _tooltip) && ret;
+			}
+		}
+
+		this.m.IsUpdating = wasUpdating;
+		return ret;
+	}
+});

--- a/dynamic_perks/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/dynamic_perks/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -74,7 +74,8 @@
 				});
 			}
 
-			if (::MSU.isIn("verifyPrerequisites", perk, true)) perk.verifyPrerequisites(player, ret);
+			perk.isUnlockable(player, ret);
+			player.getSkills().isPerkUnlockable(_perkId, ret);
 		}
 
 		return ret;

--- a/scripts/!mods_preload/dynamic_perks.nut
+++ b/scripts/!mods_preload/dynamic_perks.nut
@@ -57,10 +57,19 @@
 	{
 		func();
 	}
+
+	// Default function added to all perkDefs which don't have it defined
+	local isUnlockable = @( _player, _tooltip ) true;
+
 	foreach (perkDef in ::Const.Perks.LookupMap)
 	{
 		// Is populated during ::DynamicPerks.PerkGroups.add/remove and perk_group.addPerk/RemovePerk
 		perkDef.PerkGroupIDs <- [];
+
+		if (!::MSU.isIn("isUnlockable", perkDef, true))
+		{
+			perkDef.isUnlockable <- isUnlockable;
+		}
 	}
 }, ::Hooks.QueueBucket.VeryLate)
 


### PR DESCRIPTION
- Change perkDef.verifyPrerequisites function name to a more standard perkDef.isUnlockable. This breaks backwards compatibility.
- Add isUnlockable to all perkDefs by default and return true.
- Add isPerkUnlockable event for skills.

This will keep things a lot cleaner on the modding side e.g. if you want Duelist to disable someone from picking Battle Forged all you have to do is add the `isPerkUnlockable` function inside `Duelist` and return false for Battle Forged.

Question:
Unfortunately the logic about a perk's own unlockability cannot be defined within the perk's skill file using the new `skill.isPerkUnlockable` function. It can only contain logic about verifying the unlockability of OTHER skills. Because when the actor doesn't have the skill, naturally this function isn't called for this skill. So the logic about a perk's own unlockability (e.g. become unlockable after the actor is level 3) must be defined within the perkDef. However, there _is_ a hacky way to work around this i.e. allow the `skill.isPerkUnlockable` function to contain logic about the perk itself. That would require creating a perkID to perkFilename map and then every time the tooltip is queried, we instantiate a perk object, set its container to the player's skill container, call its `isPerkUnlockable` function with the perk's own ID and then let the object be garbage collected. Is this worth doing? This also has the benefit of perhaps easier submoddability via cleaner hooks. Or do we keep the separation of: perk's own unlockability definition goes in perkdef and logic about it affecting others goes in its skill file? 

EDIT: Actually this might have a significant impact on performance because whenever you open the inventory screen we call `player.isPerkUnlockable` in Dynamic Perks Framework for every single perk in the perk tree of ALL brothers. So, this might lead to a TON of instantiations along with 100s of skill_container events. Even if we instantiate and cache the skill object at the start of the game, it's still 100s of skill_container events. So a different approach has to be thought of. 

Example:
```squirrel
// inside duelist to disable someone with duelist perk from unlocking battle forged:
function isPerkUnlockable( _perkID, _tooltip )
{
	if (_perkID == "perk.battle_forged")
	{
		_tooltip.push({
			id = 3,
			type = "hint",
			icon = "ui/icons/icon_locked.png",
			text = "Locked because this character has the Duelist perk"
		});
		return false;
	}
	return true;
}

// inside a perk def to disable itself from being unlockable based on certain conditions:
{
	ID = "perk.rf_promised_potential",
	Script = "scripts/skills/perks/perk_rf_promised_potential",
	Name = ::Const.Strings.PerkName.RF_PromisedPotential,
	Tooltip = ::Const.Strings.PerkDescription.RF_PromisedPotential,
	Icon = "ui/perks/perk_rf_promised_potential.png",
	IconDisabled = "ui/perks/perk_rf_promised_potential_sw.png",
	function isUnlockable( _player, _tooltip )
	{
		if (_player.getPerkPointsSpent() > 0)
		{
			_tooltip.push({
				id = 3,
				type = "hint",
				icon = "ui/icons/icon_locked.png",
				text = "Locked because this character has already spent a perk point"
			});
			return false;
		}
		return true;
	}
}
```