### PR TITLE
fix: don't include nameless perk groups in perk groups of perks

### DIFF
--- a/dynamic_perks/config.nut
+++ b/dynamic_perks/config.nut
@@ -115,11 +115,14 @@
 		if (_perkGroup.getID() in this.LookupMap) throw ::MSU.Exception.DuplicateKey(_perkGroup.getID());
 		this.LookupMap[_perkGroup.getID()] <- _perkGroup;
 
-		foreach (row in _perkGroup.getTree())
+		if (_perkGroup.getName() != "")
 		{
-			foreach (perkID in row)
+			foreach (row in _perkGroup.getTree())
 			{
-				::DynamicPerks.Perks.__addPerkGroupToPerkDef(_perkGroup.getID(), ::Const.Perks.findById(perkID));
+				foreach (perkID in row)
+				{
+					::DynamicPerks.Perks.__addPerkGroupToPerkDef(_perkGroup.getID(), ::Const.Perks.findById(perkID));
+				}
 			}
 		}
 	}

--- a/scripts/mods/mod_dynamic_perks/classes/perk_group.nut
+++ b/scripts/mods/mod_dynamic_perks/classes/perk_group.nut
@@ -156,7 +156,8 @@ this.perk_group <- {
 
 		this.getTree()[_tier-1].push(_id);
 
-		::DynamicPerks.Perks.__addPerkGroupToPerkDef(this.getID(), ::Const.Perks.findById(_id));
+		if (this.getName() != "")
+			::DynamicPerks.Perks.__addPerkGroupToPerkDef(this.getID(), ::Const.Perks.findById(_id));
 	}
 
 	function removePerk( _id )


### PR DESCRIPTION
This is similar to how nameless perk groups are excluded in the tooltip of perks in `tooltip_events.general_queryUIPerkTooltipData`. The idea is that only perk groups with names can be used as a reference point for the player in the perk tree. Nameless perk groups can be used for other purposes e.g. a custom perk group for enemies.

I am not fully satisfied with this solution, but it seems reasonable for now. Eventually we may want to add a new member variable in perk groups to exclude them or change how perk groups are organized in the framework.

Related issue on Reforged discord server: https://discord.com/channels/1006908336991645757/1391793789399601224